### PR TITLE
Add VSCode launch configuration for Next.js debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug client-side (Firefox)",
+      "type": "firefox",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "reAttach": true,
+      "pathMappings": [
+        {
+          "url": "webpack://_N_E",
+          "path": "${workspaceFolder}"
+        }
+      ]
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/.bin/next",
+      "runtimeArgs": ["--inspect"],
+      "skipFiles": ["<node_internals>/**"],
+      "serverReadyAction": {
+        "action": "debugWithEdge",
+        "killOnServerStop": true,
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s",
+        "webRoot": "${workspaceFolder}"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a new configuration file for Visual Studio Code to facilitate debugging for a Next.js application. The file `.vscode/launch.json` includes multiple debug configurations for both server-side and client-side debugging.

Debugging configurations added:

* Added a configuration for debugging server-side code using `node-terminal` and the command `npm run dev`.
* Added a configuration for debugging client-side code using Chrome with the URL `http://localhost:3000`.
* Added a configuration for debugging client-side code using Firefox, including re-attachment and path mappings.
* Added a configuration for full-stack debugging using the Next.js runtime with inspection and server ready actions.