### PR TITLE
Fix/calendar week range

### DIFF
--- a/src/app/(protected)/calendar/page.tsx
+++ b/src/app/(protected)/calendar/page.tsx
@@ -60,10 +60,10 @@ export default function CalendarPage() {
     setWeekStartDate(startOfWeek(new Date(), { weekStartsOn: 1 }));
   }, []);
 
-  const [weekEndDate, setWeekEndDate] = useState<Date | undefined>();
-  useEffect(() => {
-    setWeekEndDate(endOfWeek(new Date(), { weekStartsOn: 1 }));
-  }, []);
+  const weekEndDate = useMemo(() => {
+    if (!weekStartDate) return undefined;
+    return endOfWeek(weekStartDate, { weekStartsOn: 1 });
+  }, [weekStartDate]);
 
   const [events, setEvents] = useState<ClientCalendarEvent[]>([]);
   const [isLoadingEvents, setIsLoadingEvents] = useState(true);
@@ -134,16 +134,10 @@ export default function CalendarPage() {
     setWeekStartDate(
       (prev) => prev && startOfWeek(subWeeks(prev, 1), { weekStartsOn: 1 })
     );
-    setWeekEndDate(
-      (prev) => prev && endOfWeek(subWeeks(prev, 1), { weekStartsOn: 1 })
-    );
   };
   const handleNextWeek = () => {
     setWeekStartDate(
       (prev) => prev && startOfWeek(addWeeks(prev, 1), { weekStartsOn: 1 })
-    );
-    setWeekEndDate(
-      (prev) => prev && endOfWeek(addWeeks(prev, 1), { weekStartsOn: 1 })
     );
   };
   const handleToday = () =>

--- a/src/app/(protected)/calendar/page.tsx
+++ b/src/app/(protected)/calendar/page.tsx
@@ -396,6 +396,7 @@ export default function CalendarPage() {
                 onClick={handlePreviousWeek}
                 size="icon"
                 aria-label="Previous week"
+                title="Previous week"
                 disabled={!weekStartDate || isLoadingEvents}
               >
                 <ChevronLeft className="h-4 w-4" />
@@ -412,6 +413,7 @@ export default function CalendarPage() {
                 onClick={handleNextWeek}
                 size="icon"
                 aria-label="Next week"
+                title="Next week"
                 disabled={!weekStartDate || isLoadingEvents}
               >
                 <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
This pull request refactors the `CalendarPage` component in `src/app/(protected)/calendar/page.tsx` to improve state management and enhance accessibility. The most significant changes involve replacing the `weekEndDate` state with a `useMemo` hook and adding `title` attributes to navigation buttons.

### State management improvements:
* Replaced the `weekEndDate` state with a `useMemo` hook to derive its value based on `weekStartDate`, simplifying the code and reducing unnecessary state updates.
* Removed redundant updates to `weekEndDate` in `handlePreviousWeek` and `handleNextWeek` functions since it is now computed dynamically.

### Accessibility enhancements:
* Added `title` attributes to the "Previous week" and "Next week" navigation buttons to improve accessibility and provide additional context for screen readers.