### PR TITLE
Fix/ai msg id issue

### DIFF
--- a/src/app/(protected)/chat/[chatId]/ChatPageClient.tsx
+++ b/src/app/(protected)/chat/[chatId]/ChatPageClient.tsx
@@ -320,10 +320,10 @@ export default function ChatPageClient({
     id: chatId,
     sendExtraMessageFields: true,
     initialMessages: initialMessages,
-    experimental_prepareRequestBody(data) {
+    experimental_prepareRequestBody({ messages, id }) {
       return {
-        message: data.messages[data.messages.length - 1],
-        id: data.id,
+        message: messages[messages.length - 1],
+        id: id,
         ...(clientTimezone && { timezone: clientTimezone }),
       };
     },

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -157,11 +157,20 @@ export async function POST(req: Request) {
     messages,
     maxSteps: 10,
     async onFinish({ response }) {
+      if (!response || !response.messages || response.messages.length === 0) {
+        return;
+      }
+      const firstMessageId = response.messages[0].id;
+      const lastMessageId = response.messages[response.messages.length - 1].id;
+
       appendResponseMessages({
         messages,
         responseMessages: response.messages,
       }).forEach((msg) => {
-        addMessageToRedisChat(id, msg);
+        addMessageToRedisChat(
+          chatId,
+          msg.id === firstMessageId ? { ...msg, id: lastMessageId } : msg
+        );
       });
     },
     maxTokens: 8192,

--- a/src/app/api/ai/chat/route.ts
+++ b/src/app/api/ai/chat/route.ts
@@ -56,13 +56,13 @@ export async function POST(req: Request) {
     return new Response('User not found', { status: 404 });
   }
 
-  const { id, message, timezone } = await req.json();
+  const { id: chatId, message, timezone } = await req.json();
 
-  if (!id || !message || !timezone) {
+  if (!chatId || !message || !timezone) {
     return new Response('Invalid request data', { status: 400 });
   }
 
-  if (typeof id !== 'string' || typeof timezone !== 'string') {
+  if (typeof chatId !== 'string' || typeof timezone !== 'string') {
     return new Response('Invalid request data types', { status: 400 });
   }
 
@@ -77,7 +77,7 @@ export async function POST(req: Request) {
     return new Response('Invalid message format', { status: 400 });
   }
 
-  const previousMessages = await getMessagesFromRedisChat(id);
+  const previousMessages = await getMessagesFromRedisChat(chatId);
 
   const messages = appendClientMessage({
     messages: previousMessages,


### PR DESCRIPTION
This pull request refactors the handling of chat IDs and message data in the `ChatPageClient` and `POST` API route to improve clarity and consistency. The changes primarily focus on renaming variables for better readability and modifying message processing logic to ensure proper handling of response messages.

### Refactoring for clarity and consistency:

* **Variable renaming for better readability**:
  - Renamed `id` to `chatId` in `src/app/api/ai/chat/route.ts` to make the purpose of the variable clearer.

### Improvements to message processing:

* **Enhanced response message handling**:
  - Updated the logic in `src/app/api/ai/chat/route.ts` to ensure the first message ID in the response is replaced with the last message ID during Redis storage, improving message consistency.

* **Refactored request body preparation**:
  - Simplified the `experimental_prepareRequestBody` method in `src/app/(protected)/chat/[chatId]/ChatPageClient.tsx` by using destructuring and clearer variable names.